### PR TITLE
Use $SSH_CONNECTION

### DIFF
--- a/agkozak-zsh-theme.plugin.zsh
+++ b/agkozak-zsh-theme.plugin.zsh
@@ -45,7 +45,7 @@ setopt PROMPT_SUBST
 [[ $AGKOZAK_PROMPT_DIRTRIM -ge 1 ]] || AGKOZAK_PROMPT_DIRTRIM=2
 
 _agkozak_is_ssh() {
-  if [[ -n $SSH_CLIENT ]] || [[ -n $SSH_TTY ]]; then
+  if [[ -n $SSH_CONNECTION ]]; then
     true
   else
     case $EUID in


### PR DESCRIPTION
I've been using this for a while but recently noticed an inconsistency with showing the hostname. I'm using tmux, having one session when on the computer directly and a separate session when I connect via SSH. One of two scenarios occur:

1. If I start a session first in the computer directly, the hostname does not show. However, if I then start a session via SSH while the other session is still open the hostname still doesn't show.

2. If I start a session first via SSH, the hostname does show. However, if I then start a session directly while the other session is open the hostname still shows.

In both cases I observe the environment variables and it seems that `SSH_CLIENT` and `SSH_TTY` are not reliable in determining if I'm in an SSH session. The only environment variable that is consistent is `SSH_CONNECTION`, plus other ZSH themes I've observed also use `SSH_CONNECTION`. I also tried using `SSH_CONNECTION` without tmux and it seems to work properly.