### PR TITLE
Custom Prompt Colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,14 @@ Demo:
 
 [![agkozak-zsh-theme (Singe-Line)](https://asciinema.org/a/155904.png)](https://asciinema.org/a/155904)
 
+## Custom Colors
+If you'd like to customize the prompt colors, change any of the `AGKOZAK_COLORS_*` variables from their defaults to any valid color and add it to your `.zshrc`. The following are the available color variables and their defaults:
+
+    AGKOZAK_COLORS_EXIT_STATUS=red
+    AGKOZAK_COLORS_USER_HOST=green
+    AGKOZAK_COLORS_PATH=blue
+    AGKOZAK_COLORS_BRANCH_STATUS=yellow
+
 ## Asynchronous Methods
 
 agkozak-zsh-theme has two different ways of displaying its Git status asynchronously and thereby of keeping the prompt swift: it uses the [`zsh-async`](https://github.com/mafredri/zsh-async) library when possible, falling back when necessary on a method described by [Anish Athalye](http://www.anishathalye.com/2015/02/07/an-asynchronous-shell-prompt/).

--- a/agkozak-zsh-theme.plugin.zsh
+++ b/agkozak-zsh-theme.plugin.zsh
@@ -56,10 +56,15 @@ AGKOZAK_THEME_DEBUG=${AGKOZAK_THEME_DEBUG:-0}
 # Set $AGKOZAK_MULTILINE to 0 to enable the legacy, single-line prompt
 typeset -g AGKOZAK_MULTILINE=${AGKOZAK_MULTILINE:-1}
 
-# Set $AGKOZAK_COLORS_* to any valid color to change the color of the exit status, username/hostname, and path
+# Set $AGKOZAK_COLORS_* variables to any valid color
+#   AGKOZAK_COLORS_EXIT_STATUS changes the exit status color     (default: red)
+#   AGKOZAK_COLORS_USER_HOST changes the username/hostname color (default: green)
+#   AGKOZAK_COLORS_PATH changes the path color                   (default: blue)
+#   AGKOZAK_COLORS_BRANCH_STATUS changes the branch status color (default: yellow)
 typeset -g AGKOZAK_COLORS_EXIT_STATUS=${AGKOZAK_COLORS_EXIT_STATUS:-red}
 typeset -g AGKOZAK_COLORS_USER_HOST=${AGKOZAK_COLORS_USER_HOST:-green}
 typeset -g AGKOZAK_COLORS_PATH=${AGKOZAK_COLORS_PATH:-blue}
+typeset -g AGKOZAK_COLORS_BRANCH_STATUS=${AGKOZAK_COLORS_BRANCH_STATUS:-yellow}
 
 setopt PROMPT_SUBST NO_PROMPT_BANG
 
@@ -498,7 +503,7 @@ agkozak_zsh_theme() {
   else
     if _agkozak_has_colors; then
       PS1=$'%(?..%B%F{${AGKOZAK_COLORS_EXIT_STATUS}}(%?%)%f%b )%(!.%S%B.%B%F{${AGKOZAK_COLORS_USER_HOST}})%n%1v%(!.%b%s.%f%b) %B%F{${AGKOZAK_COLORS_PATH}}%2v%f%b${AGKOZAK_PROMPT_WHITESPACE}$(_agkozak_vi_mode_indicator) '
-      RPS1='%F{yellow}%3v%f'
+      RPS1='%F{${AGKOZAK_COLORS_BRANCH_STATUS}}%3v%f'
     else
       PS1=$'%(?..(%?%) )%(!.%S.)%n%1v%(!.%s.) %2v${AGKOZAK_PROMPT_WHITESPACE}$(_agkozak_vi_mode_indicator) '
       RPS1='%3v'

--- a/agkozak-zsh-theme.plugin.zsh
+++ b/agkozak-zsh-theme.plugin.zsh
@@ -56,6 +56,11 @@ AGKOZAK_THEME_DEBUG=${AGKOZAK_THEME_DEBUG:-0}
 # Set $AGKOZAK_MULTILINE to 0 to enable the legacy, single-line prompt
 typeset -g AGKOZAK_MULTILINE=${AGKOZAK_MULTILINE:-1}
 
+# Set $AGKOZAK_COLORS_* to any valid color to change the color of the exit status, username/hostname, and path
+typeset -g AGKOZAK_COLORS_EXIT_STATUS=${AGKOZAK_COLORS_EXIT_STATUS:-red}
+typeset -g AGKOZAK_COLORS_USER_HOST=${AGKOZAK_COLORS_USER_HOST:-green}
+typeset -g AGKOZAK_COLORS_PATH=${AGKOZAK_COLORS_PATH:-blue}
+
 setopt PROMPT_SUBST NO_PROMPT_BANG
 
 ############################################################
@@ -492,7 +497,7 @@ agkozak_zsh_theme() {
     unset zle_bracketed_paste
   else
     if _agkozak_has_colors; then
-      PS1=$'%(?..%B%F{red}(%?%)%f%b )%(!.%S%B.%B%F{green})%n%1v%(!.%b%s.%f%b) %B%F{blue}%2v%f%b${AGKOZAK_PROMPT_WHITESPACE}$(_agkozak_vi_mode_indicator) '
+      PS1=$'%(?..%B%F{${AGKOZAK_COLORS_EXIT_STATUS}}(%?%)%f%b )%(!.%S%B.%B%F{${AGKOZAK_COLORS_USER_HOST}})%n%1v%(!.%b%s.%f%b) %B%F{${AGKOZAK_COLORS_PATH}}%2v%f%b${AGKOZAK_PROMPT_WHITESPACE}$(_agkozak_vi_mode_indicator) '
       RPS1='%F{yellow}%3v%f'
     else
       PS1=$'%(?..(%?%) )%(!.%S.)%n%1v%(!.%s.) %2v${AGKOZAK_PROMPT_WHITESPACE}$(_agkozak_vi_mode_indicator) '


### PR DESCRIPTION
Hey, Agkozak!

I thought I'd try to contribute to this awesome ZSH prompt by suggesting a feature that I think many would like: Custom prompt colors. Today while at work, I realized I wanted to use this ZSH theme between two non-root users on my workstation, but found that without color to change things up, it was hard to distinguish between the two. Here's where the `AGKOZAK_COLORS_*` variables come in.

In this pull request, I've added four new global variables users can optionally set within their `.zshrc`:

- `AGKOZAK_COLORS_EXIT_STATUS` to change the exit status color (default: red)
- `AGKOZAK_COLORS_USER_HOST` to change the username/hostname color (default: green)
- `AGKOZAK_COLORS_PATH` to change the path color (default: blue)
- `AGKOZAK_COLORS_BRANCH_STATUS` to change the git branch status color (default: yellow)

Of course, these variables have defaults that match the current hard-coded prompt colors, so this change should have no adverse effects to users who do not wish to change these. In addition, I've updated the `README.md` to include some simple documentation on these new variables.

Let me know if you have any questions or concerns, or if you need me to change anything. Once again, awesome prompt, dude!