### PR TITLE
Show hostname when inside containers too

### DIFF
--- a/agkozak-zsh-prompt.plugin.zsh
+++ b/agkozak-zsh-prompt.plugin.zsh
@@ -1033,7 +1033,7 @@ prompt_agkozak-zsh-prompt_setup() {
   fi
 
   # Only display the HOSTNAME for an SSH connection or for a superuser
-  if _agkozak_is_ssh || (( EUID == 0 )); then
+  if _agkozak_is_ssh || (( EUID == 0 )) || test -f /run/.containerenv; then
     psvar[1]="@${(%):-%m}"
   else
     psvar[1]=''


### PR DESCRIPTION
`distrobox` (and other toolbox-like containers) set a hostname, and it is useful to be able to distinguish whether you are inside the container or outside.
When /run/.containerenv is present then show the hostname, just as if it was an SSH-ed remote host.